### PR TITLE
[fix]: Add space between signup and cancel button and Positioning.

### DIFF
--- a/style.css
+++ b/style.css
@@ -683,6 +683,10 @@ input[type=text], input[type=password] {
     cursor: pointer;
   }
   
+  .clearfix {
+    display: flex;
+    gap: 10px;
+  }
 
   /* Clear floats */
   .clearfix::after {


### PR DESCRIPTION
Fix issue: #8 

fix this:
Add a gap between the signup button and cancel button and add a proper positioning.

How to reproduce the error:
1.go to homepage
2.click on create account button